### PR TITLE
Add reference for more security incidents reviewed

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -5,3 +5,5 @@ This page links to noted issues that would have potentially been mitigated or ad
 - [Snyk blog on bootsrap_sass issue](https://snyk.io/blog/malicious-remote-code-execution-backdoor-discovered-in-the-popular-bootstrap-sass-ruby-gem/)
 - [NPM malicious module](https://blog.npmjs.org/post/173526807575/reported-malicious-module-getcookies)
 - [Event Stream Issue](https://github.com/dominictarr/event-stream/issues/116)
+
+More Node.js related security incidents tracked in the [Awesome Node.js Security](https://github.com/lirantal/awesome-nodejs-security#security-incidents) repository.


### PR DESCRIPTION
I am tracking all of the supply chain security incidents around JavaScript or npmjs in a dedicated repository so perhaps worth to add a reference instead of duplicating the data.